### PR TITLE
Quick SELinux fix

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -409,8 +409,17 @@ class backuppc::client (
       mode    => '0700',
       owner   => $system_account,
       group   => $system_account,
+      seltype => 'ssh_home_t',
     }
-
+    
+    file { "${system_home_directory}/.ssh/authorized_keys":
+      ensure  => $file_ensure,
+      mode    => '0600',
+      owner   => $system_account,
+      group   => $system_account,
+      seltype => 'ssh_home_t',
+    }
+    
     file { "${system_home_directory}/backuppc.sh":
       ensure  => $file_ensure,
       owner   => 'root',


### PR DESCRIPTION
Without this, the file /var/backup/.ssh/authorized_keys ends up with its SELinux label showing the var_t type, rather than ssh_home_t.  This, in turn, means that the file can't be read by the backup user.  So backups may fail on SELinux-enabled hosts without this.  HTH!