### PR TITLE
Major updates - see description

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,22 +16,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: 2.5.9
-            puppet: 6
+          - ruby: 2.7.8
+            puppet: 7
             fixtures: .fixtures.yml
             allow_failure: false
-          - ruby: 2.7.6
-            puppet: 7
+          - ruby: 3.2.3
+            puppet: 8
             fixtures: .fixtures.yml
             allow_failure: false
     env:
       BUNDLE_WITHOUT: system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
-      FACTER_GEM_VERSION: "< 4.0"
       FIXTURES_YML: ${{ matrix.fixtures }}
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -49,17 +48,15 @@ jobs:
       fail-fast: false
       matrix:
         set:
-          - "el7"
           - "el8"
           - "el9"
-          - "debian-10"
           - "debian-11"
-          - "ubuntu-1804"
           - "ubuntu-2004"
           - "ubuntu-2204"
+          - "ubuntu-2404"
         puppet:
-          - "puppet6"
           - "puppet7"
+          - "puppet8"
     env:
       BUNDLE_WITHOUT: development:release
       BEAKER_debug: true
@@ -74,9 +71,10 @@ jobs:
         run: |
             set -x
             sudo apt-get remove mysql-server --purge
+            sudo apt-get update
             sudo apt-get install apparmor-profiles
             sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,15 @@ Style/TernaryParentheses:
 Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInArrayLiteral:
+  Description: Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInHashLiteral:
+  Description: Prefer always trailing comma on multiline argument lists. This makes
+    diffs, and re-ordering nicer.
+  EnforcedStyleForMultiline: consistent_comma
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,17 +2,16 @@
 .github/workflows/ci.yaml:
   acceptance_matrix:
       set:
-        - el7
+        - ---el7
         - el8
         - el9
-        - debian-10
         - debian-11
-        - ubuntu-1804
         - ubuntu-2004
         - ubuntu-2204
+        - ubuntu-2404
       puppet:
-        - puppet6
         - puppet7
+        - puppet8
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "voxpupuli-test", '5.4.1',    require: false
+  gem "voxpupuli-test", '7.0.0',    require: false
   gem "faraday", '~> 1.0',          require: false
   gem "github_changelog_generator", require: false
   gem "puppet-blacksmith",          require: false
@@ -29,8 +29,8 @@ group :system_tests do
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
-  gem "beaker-docker"
-  gem "beaker-puppet"
+  gem "beaker-docker",               git: 'https://github.com/treydock/beaker-docker.git', branch: 'amazon-2023'
+  gem "beaker-puppet",               git: 'https://github.com/puppetlabs/beaker-puppet.git', ref: '6063d22b6c4449df795731f5853c3c75241240c4'
   gem "beaker-puppet_install_helper",                                            require: false
   gem "beaker-module_install_helper",                                            require: false
 end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -219,7 +219,7 @@ class backuppc::client (
   if $xfer_method in ['rsync', 'tar'] {
     if $xfer_method == 'rsync' {
       if $manage_rsync and $ensure == 'present' {
-        ensure_packages(['rsync'])
+        stdlib::ensure_packages(['rsync'])
       }
       $sudo_command_noexec = $rsync_path
     }

--- a/metadata.json
+++ b/metadata.json
@@ -10,66 +10,62 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <9.0.0"
+      "version_requirement": ">= 9.0.0 <10.0.0"
     },
     {
       "name": "puppet/epel",
-      "version_requirement": ">= 3.0.0 <5.0.0"
+      "version_requirement": ">= 3.0.0 <6.0.0"
     },
     {
       "name": "saz/sudo",
-      "version_requirement": ">= 7.0.0 <8.0.0"
+      "version_requirement": ">= 7.0.0 <10.0.0"
     }
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "2.1.0",
+  "pdk-version": "2.7.1",
   "template-url": "https://github.com/treydock/pdk-templates.git#master",
-  "template-ref": "heads/master-0-g978d356"
+  "template-ref": "heads/master-0-gd2de99e"
 }

--- a/spec/acceptance/nodesets/debian-12.yml
+++ b/spec/acceptance/nodesets/debian-12.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  debian10:
+  debian12:
     roles:
       - agent
-    platform: debian-10-amd64
+    platform: debian-12-amd64
     hypervisor: docker
-    image: debian:10
+    image: debian:12
     docker_preserve_image: true
     docker_cmd:
       - '/sbin/init'
@@ -18,7 +18,7 @@ HOSTS:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-    docker_container_name: 'backuppc-debian10'
+    docker_container_name: 'backuppc-debian12'
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/acceptance/nodesets/el8.yml
+++ b/spec/acceptance/nodesets/el8.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  rocky-8:
+  el8:
     roles:
       - agent
     platform: el-8-x86_64
     hypervisor: docker
-    image: almalinux:8
+    image: rockylinux:8
     docker_preserve_image: true
     docker_cmd:
       - '/usr/sbin/init'

--- a/spec/acceptance/nodesets/el9.yml
+++ b/spec/acceptance/nodesets/el9.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  almalinux-9:
+  el9:
     roles:
       - agent
     platform: el-9-x86_64
     hypervisor: docker
-    image: almalinux:9
+    image: rockylinux:9
     docker_preserve_image: true
     docker_cmd:
       - '/usr/sbin/init'

--- a/spec/acceptance/nodesets/ubuntu-2404.yml
+++ b/spec/acceptance/nodesets/ubuntu-2404.yml
@@ -1,21 +1,21 @@
 HOSTS:
-  ubuntu1804:
+  ubuntu2404:
     roles:
       - agent
-    platform: ubuntu-18.04-amd64
+    platform: ubuntu-24.04-amd64
     hypervisor : docker
-    image: ubuntu:18.04
+    image: ubuntu:24.04
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
-      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates lsb-release'
+      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates'
       - 'locale-gen en_US.UTF-8'
     docker_env:
       - LANG=en_US.UTF-8
       - LANGUAGE=en_US.UTF-8
       - LC_ALL=en_US.UTF-8
-    docker_container_name: 'backuppc-ubuntu1804'
+    docker_container_name: 'backuppc-ubuntu2404'
 CONFIG:
   log_level: debug
   type: foss

--- a/spec/classes/backuppc_client_spec.rb
+++ b/spec/classes/backuppc_client_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'backuppc::client' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "when #{os}" do
       let(:facts) do
         facts
       end

--- a/spec/classes/backuppc_server_spec.rb
+++ b/spec/classes/backuppc_server_spec.rb
@@ -7,19 +7,19 @@ describe 'backuppc::server' do
                     supported_os: [
                       {
                         'operatingsystem' => 'RedHat',
-                        'operatingsystemrelease' => ['8']
+                        'operatingsystemrelease' => ['8'],
                       },
                       {
                         'operatingsystem' => 'Debian',
-                        'operatingsystemrelease' => ['11']
+                        'operatingsystemrelease' => ['11'],
                       },
                       {
                         'operatingsystem' => 'Ubuntu',
-                        'operatingsystemrelease' => ['22.04']
-                      }
-                    ]
+                        'operatingsystemrelease' => ['22.04'],
+                      },
+                    ],
                   }).each do |os, facts|
-    context "on #{os}" do
+    context "when #{os}" do
       let(:facts) do
         facts
       end
@@ -32,11 +32,11 @@ describe 'backuppc::server' do
                     supported_os: [
                       {
                         'operatingsystem' => 'RedHat',
-                        'operatingsystemrelease' => ['7']
-                      }
-                    ]
+                        'operatingsystemrelease' => ['7'],
+                      },
+                    ],
                   }).each do |os, facts|
-    context "on #{os}" do
+    context "when #{os}" do
       let(:facts) do
         facts
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,19 +13,19 @@ include RspecPuppetFacts # rubocop:disable Style/MixinUsage
 
 default_facts = {
   puppetversion: Puppet.version,
-  facterversion: Facter.version
+  facterversion: Facter.version,
 }
 
 default_fact_files = [
   File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
-  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml'))
+  File.expand_path(File.join(File.dirname(__FILE__), 'default_module_facts.yml')),
 ]
 
 default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+    default_facts.merge!(YAML.safe_load(File.read(f)))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -9,7 +9,8 @@ dir = __dir__
 Dir["#{dir}/acceptance/shared_examples/**/*.rb"].sort.each { |f| require f }
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
-run_puppet_install_helper
+run_puppet_install_helper unless ['debian-12', 'ubuntu-2404'].include?(ENV['BEAKER_set'])
+on hosts, 'apt install -y puppet-agent' if ['debian-12', 'ubuntu-2404'].include?(ENV['BEAKER_set'])
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 


### PR DESCRIPTION
* Drop Debian 10
* Drop Ubuntu 18.04
* Drop EL7
* Add Debian 12
* Add Ubuntu 24.04
* Add EL9
* Require stdlib 9.x
* Support newer module version ranges
* Drop Puppet 6
* Add Puppet 8